### PR TITLE
Add Jekyll blog system

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+
+      - name: Build Blog (Jekyll)
+        run: |
+          mkdir -p blog
+          bundle exec jekyll build --source _blog --destination blog
+
+      - name: Commit and push changes
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add blog/
+          git diff-index --quiet HEAD || git commit -m "Auto-rebuild blog"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 .idea/
 .DS_Store
+vendor/
+.jekyll-cache/
+_site/
+.jekyll-metadata

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gem "jekyll"
+gem "jekyll-feed"
+gem "minima"

--- a/_blog/_config.yml
+++ b/_blog/_config.yml
@@ -1,0 +1,11 @@
+title: Attogram Blog
+email: your-email@example.com
+description: >- # this means to ignore newlines until "baseurl:"
+  A simple Jekyll blog.
+baseurl: "/blog" # the subpath of your site, e.g. /blog
+url: "" # the base hostname & protocol for your site, e.g. http://example.com
+
+# Build settings
+theme: minima
+plugins:
+  - jekyll-feed

--- a/_blog/_layouts/default.html
+++ b/_blog/_layouts/default.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="{{ page.lang | default: site.lang | default: "en" }}">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{{ page.title | default: site.title }}</title>
+  <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
+</head>
+<body>
+  <header>
+    <h1>{{ site.title }}</h1>
+  </header>
+  <main>
+    {{ content }}
+  </main>
+  <footer>
+    <p>&copy; {{ site.time | date: "%Y" }}</p>
+  </footer>
+</body>
+</html>

--- a/_blog/_layouts/post.html
+++ b/_blog/_layouts/post.html
@@ -1,0 +1,11 @@
+---
+layout: default
+---
+<article>
+  <header>
+    <h1>{{ page.title }}</h1>
+    <p>{{ page.date | date: "%b %-d, %Y" }}</p>
+  </header>
+  {{ content }}
+</article>
+<p><a href="{{ site.baseurl }}/">&larr; Back to blog index</a></p>

--- a/_blog/_posts/2025-07-08-welcome.md
+++ b/_blog/_posts/2025-07-08-welcome.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title: "Welcome to my blog"
+date: 2025-07-08 12:00:00 +0000
+categories: jekyll update
+---
+
+# Welcome!
+
+This is the first post of my new Jekyll-based blog. It's built using standard software and is easy to maintain.
+
+You can add more posts by creating Markdown files in the `_blog/_posts/` directory.

--- a/_blog/assets/css/style.scss
+++ b/_blog/assets/css/style.scss
@@ -1,0 +1,3 @@
+---
+---
+@import "minima";

--- a/_blog/index.md
+++ b/_blog/index.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: Blog
+---
+
+# Blog
+
+Welcome to the blog!
+
+## Posts
+
+<ul>
+  {% for post in site.posts %}
+    <li>
+      <span class="post-date">{{ post.date | date: "%b %-d, %Y" }}</span>
+      <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a>
+    </li>
+  {% endfor %}
+</ul>
+
+<p><a href="../">&larr; Back to Portfolio</a></p>


### PR DESCRIPTION
I have added a standard Jekyll-based blog system to your repository.

### Key Features:
- **Standard Software:** Uses Jekyll, the built-in blog engine for GitHub Pages.
- **Isolated:** All blog source files are in `_blog/`, keeping your portfolio files completely untouched.
- **Automated Build:** A new GitHub Action automatically builds your blog into the `/blog` folder whenever you push to `main`.
- **Easy to Use:** Just add new Markdown posts to `_blog/_posts/` via a Pull Request.

### Changes:
- `_blog/`: Contains the Jekyll source, posts, and layouts.
- `.github/workflows/build.yml`: Automates the blog building process (does not touch your portfolio builder).
- `Gemfile`: Lists the standard Ruby dependencies for Jekyll.
- `.gitignore`: Updated to ignore local Jekyll artifacts.

Your portfolio's `index.html` and `_build` folder are exactly as they were.

---
*PR created automatically by Jules for task [11271364504080617519](https://jules.google.com/task/11271364504080617519) started by @attogram*